### PR TITLE
remove registered voter requirement

### DIFF
--- a/bylaws/content.tex
+++ b/bylaws/content.tex
@@ -10,7 +10,7 @@ This organization shall be known as the \fortythird{} District Democratic Organi
 \subsection{} \label{member}
 “Member” means and includes any individual who
 \begin{inlinealphalist}
-    \item is a registered voter or, if under voting age, is eligible to become a registered voter within two years;
+    \item is at the age of 16 or above;
     \item resides within the \fortythird{} Legislative District;
     \item themself to be a Democrat; and
     \item has paid applicable dues or is a PCO.


### PR DESCRIPTION
For #14 

Encouraging members to be registered to vote is a great goal, but this rule is unlikely to be a very effective way to accomplish that, as well as further disenfranchising people who are not eligible to vote.